### PR TITLE
Specify supported platforms

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,7 @@ import PackageDescription
 
 let package = Package(
     name: "LoggingOSLog",
+    platforms: [.iOS("10.0"), .macOS("10.12"), .tvOS("10.0"), .watchOS("3.0")],
     products: [
         .library(
             name: "LoggingOSLog",


### PR DESCRIPTION
This PR updates the package manifest to specify supported platforms. Without this, the package fails to build in Xcode 11.