### PR TITLE
init with OSLog

### DIFF
--- a/Sources/LoggingOSLog/LoggingOSLog.swift
+++ b/Sources/LoggingOSLog/LoggingOSLog.swift
@@ -14,6 +14,11 @@ public struct LoggingOSLog: LogHandler {
         self.label = label
         self.oslogger = OSLog(subsystem: label, category: "")
     }
+
+    public init(label: String, log: OSLog) {
+        self.label = label
+        self.oslogger = log
+    }
     
     public func log(level: Logger.Level, message: Logger.Message, metadata: Logger.Metadata?, file: String, function: String, line: UInt) {
         var combinedPrettyMetadata = self.prettyMetadata


### PR DESCRIPTION
I want to use in my project `LoggingOSLog` in a different `OSlog`

Example
```
LoggingSystem.bootstrap { LoggingOSLog(label: $0, log: .default) }

let authLogger = Logger(label:  "middleware") { label in
    let log = OSLog(subsystem: label, category: "auth")
    return LoggingOSLog(label: $0, log: log)
}
```