### PR TITLE
Reduced availability of helper to resolve compilation errors on iOS

### DIFF
--- a/Sources/LoggingOSLog/LoggingOSLog.swift
+++ b/Sources/LoggingOSLog/LoggingOSLog.swift
@@ -64,6 +64,9 @@ public struct LoggingOSLog: LogHandler {
 }
 
 @available(OSX 10.12, *)
+@available(iOS 10.0, *)
+@available(tvOS 10.0, *)
+@available(watchOS 3.0, *)
 extension OSLogType {
     static func from(loggerLevel: Logger.Level) -> Self {
         switch loggerLevel {


### PR DESCRIPTION
If the deploy target is higher than iOS 10 in an iOS app using this package, then compilation fails with an error. This resolves that error.