### PR TITLE
Fixing import issue for Xcode 12.

### DIFF
--- a/Sources/LoggingOSLog/LoggingOSLog.swift
+++ b/Sources/LoggingOSLog/LoggingOSLog.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Logging
+import struct Logging.Logger
 import os
 
 public struct LoggingOSLog: LogHandler {


### PR DESCRIPTION
In Xcode 12, the compiler reports this `'Logger' is ambiguous for type lookup in this context`. Adding an import alias fixed the issue and package now compiles.